### PR TITLE
feat: use EnvVar and ConfigMap to make pulsar configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Apache Pulsar user-defined source and sink implemented using Java.
 #### Numaflow:
 *     mvn clean install
 *     kubectl apply -f pipeline.yaml
+*     kubectl apply -f pulsar-config-map.yaml 
 *     kubectl -n numaflow-system port-forward deployment/numaflow-server 8443:8443
 
 This builds the UDsink image, and the pipeline file uses it. Go to https://localhost:8443/ to use Numaflow UI

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -20,6 +20,17 @@ spec:
           container:
             image: my-sink:v0.0.3
             imagePullPolicy: Never
+            env:
+              - name: PULSAR_SERVICE_URL
+                valueFrom:
+                  configMapKeyRef:
+                    name: pulsar-config
+                    key: service-url
+              - name: PULSAR_TOPIC_NAME
+                valueFrom:
+                  configMapKeyRef:
+                    name: pulsar-config
+                    key: topic-name
 
   edges:
     - from: in

--- a/pulsar-config-map.yaml
+++ b/pulsar-config-map.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pulsar-config
+data:
+  service-url: "pulsar://host.docker.internal:6650"
+  topic-name: "test-topic"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,6 @@ server:
 spring:
   pulsar:
     client:
-      service-url: pulsar://host.docker.internal:6650
+      service-url: ${PULSAR_SERVICE_URL:pulsar://host.docker.internal:6650}
     producer:
-      topic-name: demo-topic
+      topic-name: ${PULSAR_TOPIC_NAME:demo-topic}


### PR DESCRIPTION
Description:
This PR introduces changes to allow configuration of the Pulsar service URL and topic name via a Kubernetes ConfigMap. This enables easier management of environment-specific configurations without changes to the image.

If user does not include an env section in the udsink section, then the service url and topic name defaults to the default values in the `application.yml `file

env section from pipeline.yaml
```bash
 env:
              - name: PULSAR_SERVICE_URL # name of env variable 
                valueFrom:
                  configMapKeyRef:
                    name: pulsar-config 
                    key: service-url #key from configmap file 
              - name: PULSAR_TOPIC_NAME
                valueFrom:
                  configMapKeyRef:
                    name: pulsar-config
                    key: topic-name
```

- Users add their desired service-url and topic name in their configMap file. 
- The deployment manifest is configured to map these environment-specific settings from the ConfigMap into environment variables inside the application's container. 
- Spring Boot's application configuration (application.yml) then reads these environment variables
-  If the environment variables are not specified within the ConfigMap, the application defaults to predetermined fallback value