### PR TITLE
feat: use pulsar client instead of pulsar template

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
-
     </dependencies>
 
     <build>

--- a/src/main/java/com/numaproj/pulsar/producer/EventPublisher.java
+++ b/src/main/java/com/numaproj/pulsar/producer/EventPublisher.java
@@ -1,40 +1,72 @@
 package com.numaproj.pulsar.producer;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.pulsar.core.PulsarTemplate;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 @Component
 @Slf4j
 public class EventPublisher {
 
+    @Value("${spring.pulsar.client.service-url}")
+    private String serviceUrl;
 
     @Value("${spring.pulsar.producer.topic-name}")
     private String topicName;
 
+    private PulsarClient pulsarClient;
+    private Producer<String> producer;
+
     @PostConstruct
     public void init() {
-        if (pulsarTemplate == null) {
-            log.error("PulsarTemplate is not instantiated!");
-        } else {
-            log.info("PulsarTemplate is successfully instantiated.");
+        try {
+            pulsarClient = PulsarClient.builder()
+                    .serviceUrl(serviceUrl)
+                    .build();
+            producer = pulsarClient.newProducer(Schema.STRING)
+                    .topic(topicName)
+                    .create();
+            log.info("PulsarClient and Producer are successfully instantiated.");
+            log.info("Loaded topic name: {}", topicName);
+        } catch (PulsarClientException e) {
+            log.error("Failed to create PulsarClient or Producer", e);
         }
-        log.info("Loaded topic name: {}", topicName);
     }
 
-    @Autowired
-    private PulsarTemplate<Object> pulsarTemplate;
-
-
-    public void publishPlainMessage(String message) throws PulsarClientException {
-        pulsarTemplate.send(topicName, message);
-        log.info("EventPublisher::publishPlainMessage publish the event {}", message);
+    public void publishPlainMessage(String message) {
+        if (producer != null) {
+            try {
+                producer.send(message);
+                log.info("EventPublisher::publishPlainMessage published the event {}", message);
+            } catch (PulsarClientException e) {
+                log.error("Failed to send message to Pulsar", e);
+            }
+        } else {
+            log.error("Producer is not initialized.");
+        }
     }
 
+    @PreDestroy
+    public void cleanup() {
+        try {
+            if (producer != null) {
+                producer.close();
+                log.info("Producer closed.");
+            }
 
+            if (pulsarClient != null) {
+                pulsarClient.close();
+                log.info("PulsarClient closed.");
+            }
+        } catch (PulsarClientException e) {
+            log.error("Error while closing PulsarClient or Producer", e);
+        }
+    }
 }


### PR DESCRIPTION
### Description 
This PR uses PulsarClient instead of PulsarTemplate as PulsarClient will allow us to more fine-tune configurations. 


Currently,  env variables are set through the configmap, which are then used in the application.yml file, which is then used the EventPublisher file. This flow will be updated in the next iteration.