### PR TITLE
fix: add producerName override

### DIFF
--- a/pulsar-config-map.yaml
+++ b/pulsar-config-map.yaml
@@ -12,5 +12,4 @@ data:
         producer:
           producerConfig: # see here for all configurations: https://pulsar.apache.org/reference/#/4.0.x/client/client-configuration-producer
             topicName: "test-config-topic" 
-            producerName: "test-producer"
             sendTimeoutMs: 2000

--- a/src/main/java/io/numaproj/pulsar/producer/PulsarConfig.java
+++ b/src/main/java/io/numaproj/pulsar/producer/PulsarConfig.java
@@ -42,19 +42,15 @@ public class PulsarConfig {
     public Producer<byte[]> pulsarProducer(PulsarClient pulsarClient, PulsarProducerProperties pulsarProducerProperties)
             throws Exception {
         String podName = env.getProperty("NUMAFLOW_POD", "pod-" + UUID.randomUUID());
-
-        if (podName == null || podName.isBlank()) {
-            podName = "pod-" + UUID.randomUUID();
-            log.warn("NUMAFLOW_POD environment variable not found. Generating fallback Producer name: {}", podName);
-        }
+        String producerName = "producerName";
 
         // Always override the user-specified producerName with the pod name
         Map<String, Object> producerConfig = pulsarProducerProperties.getProducerConfig();
-        if (producerConfig.containsKey("producerName")) {
+        if (producerConfig.containsKey(producerName)) {
             log.warn("User configured a 'producerName' in the config, but this can cause errors if multiple pods spin "
                     + "up with the same name. Overriding with '{}'", podName);
         }
-        producerConfig.put("producerName", podName);
+        producerConfig.put(producerName, podName);
         log.info("The podname is {}", podName);
 
         return pulsarClient.newProducer(Schema.BYTES)

--- a/src/main/java/io/numaproj/pulsar/producer/PulsarConfig.java
+++ b/src/main/java/io/numaproj/pulsar/producer/PulsarConfig.java
@@ -8,8 +8,10 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.pulsar.client.api.Producer;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 import io.numaproj.pulsar.config.PulsarClientProperties;
 import io.numaproj.pulsar.config.PulsarProducerProperties;
@@ -26,6 +28,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Configuration
 public class PulsarConfig {
+    @Autowired
+    private Environment env;
 
     @Bean
     public PulsarClient pulsarClient(PulsarClientProperties pulsarClientProperties) throws PulsarClientException {
@@ -37,7 +41,7 @@ public class PulsarConfig {
     @Bean
     public Producer<byte[]> pulsarProducer(PulsarClient pulsarClient, PulsarProducerProperties pulsarProducerProperties)
             throws Exception {
-        String podName = System.getenv("NUMAFLOW_POD");
+        String podName = env.getProperty("NUMAFLOW_POD", "pod-" + UUID.randomUUID());
 
         if (podName == null || podName.isBlank()) {
             podName = "pod-" + UUID.randomUUID();

--- a/src/test/java/io/numaproj/pulsar/producer/PulsarConfigTest.java
+++ b/src/test/java/io/numaproj/pulsar/producer/PulsarConfigTest.java
@@ -136,7 +136,6 @@ public class PulsarConfigTest {
         setUpProducerTest();
         
         when(mockProducerProperties.getProducerConfig()).thenReturn(new HashMap<>());
-        when(mockEnvironment.getProperty(eq("NUMAFLOW_POD"), anyString())).thenReturn("test-pod-name");
 
         String expectedErrorSubstring = "Topic name must be set on the producer builder";
         when(mockProducerBuilder.create())

--- a/src/test/java/io/numaproj/pulsar/producer/PulsarConfigTest.java
+++ b/src/test/java/io/numaproj/pulsar/producer/PulsarConfigTest.java
@@ -44,18 +44,15 @@ public class PulsarConfigTest {
 
     @Before
     public void setUp() {
-        // Initialize only the base objects needed by all tests
         pulsarConfig = new PulsarConfig();
         mockEnvironment = mock(Environment.class);
         ReflectionTestUtils.setField(pulsarConfig, "env", mockEnvironment);
         
-        // Initialize client properties used by client tests
         mockClientProperties = mock(PulsarClientProperties.class);
     }
 
     @After
     public void tearDown() {
-        // Cleanup references
         pulsarConfig = null;
         spiedConfig = null;
         mockClientProperties = null;
@@ -75,12 +72,10 @@ public class PulsarConfigTest {
         spiedConfig = spy(pulsarConfig);
         doReturn(mockClient).when(spiedConfig).pulsarClient(any(PulsarClientProperties.class));
 
-        // ProducerBuilder
         @SuppressWarnings("unchecked")
         ProducerBuilder<byte[]> builder = mock(ProducerBuilder.class);
         mockProducerBuilder = builder;
 
-        // Producer
         mockProducer = mock(Producer.class);
 
         when(mockClient.newProducer(Schema.BYTES)).thenReturn(mockProducerBuilder);
@@ -128,7 +123,6 @@ public class PulsarConfigTest {
         Map<String, Object> clientConfig = new HashMap<>();
         when(mockClientProperties.getClientConfig()).thenReturn(clientConfig);
 
-        // We expect an exception from pulsarClient(...) call
         ThrowingRunnable r = () -> pulsarConfig.pulsarClient(mockClientProperties);
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, r);
 
@@ -199,7 +193,6 @@ public class PulsarConfigTest {
     }
 
     // Test for if NUMAFLOW_POD environment variable is not set 
-
     @Test
     public void pulsarProducer_NoEnvVariableFoundFallbackName() throws Exception {
         setUpProducerTest();
@@ -217,7 +210,6 @@ public class PulsarConfigTest {
         ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
         verify(mockProducerBuilder).loadConf(captor.capture());
         String actualProducerName = (String) captor.getValue().get("producerName");
-        // Expect "pod-" + random UUID
         assertTrue(actualProducerName.startsWith("pod-"));
         assertNotEquals("pod-", actualProducerName);
     }

--- a/src/test/java/io/numaproj/pulsar/producer/PulsarConfigTest.java
+++ b/src/test/java/io/numaproj/pulsar/producer/PulsarConfigTest.java
@@ -156,13 +156,9 @@ public class PulsarConfigTest {
         assertTrue(exception.getMessage().contains(expectedErrorSubstring));
     }
 
-    /**
-     * Environment variable is set, and user does NOT specify producerName in
-     * config:
-     * we should use the environment-provided name.
-     */
+    // Test for environment variable is set, and user does NOT specify producerName 
     @Test
-    public void testProducerNameFromEnvVarNoUserConfig() throws Exception {
+    public void pulsarProducer_ProducerNameFromEnvVarNoUserConfig() throws Exception {
         setUpProducerTest();
         
         final String envPodName = "NUMAFLOW_POD_VALUE";
@@ -181,12 +177,9 @@ public class PulsarConfigTest {
         assertEquals(envPodName, configCaptor.getValue().get("producerName"));
     }
 
-    /**
-     * Environment variable is set, but user explicitly sets producerName:
-     * we warn and override with the environment-provided name anyway.
-     */
+    // Test for environment variable is set, but user explicitly sets producerName:
     @Test
-    public void testUserDefinedProducerNameOverridden() throws Exception {
+    public void pulsarProducer_ProducerNameOverridden() throws Exception {
         setUpProducerTest();
         
         final String envPodName = "my-env-pod";
@@ -205,12 +198,10 @@ public class PulsarConfigTest {
         assertEquals(envPodName, configCaptor.getValue().get("producerName"));
     }
 
-    /**
-     * If NUMAFLOW_POD environment variable is not set or blank, we generate a
-     * fallback name.
-     */
+    // Test for if NUMAFLOW_POD environment variable is not set 
+
     @Test
-    public void testNoEnvVariableFoundFallbackName() throws Exception {
+    public void pulsarProducer_NoEnvVariableFoundFallbackName() throws Exception {
         setUpProducerTest();
         
         // Return null to simulate environment variable not set

--- a/src/test/java/io/numaproj/pulsar/producer/PulsarConfigTest.java
+++ b/src/test/java/io/numaproj/pulsar/producer/PulsarConfigTest.java
@@ -118,11 +118,10 @@ public class PulsarConfigTest {
     // Test to ensure an error is thrown if pulsar client isn't created with service url
     @Test
     public void pulsarClient_missingServiceUrl_throwsException() {
-        // Missing the service URL in config so will cause an error
-        Map<String, Object> clientConfig = new HashMap<>();
+        Map<String, Object> clientConfig = new HashMap<>(); // no service URL added to cause error
         when(mockClientProperties.getClientConfig()).thenReturn(clientConfig);
 
-      IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             pulsarConfig.pulsarClient(mockClientProperties);
         });
 


### PR DESCRIPTION
## Description 
We were previously getting an error for a high RPU (~6000 for an async sink). This high RPU would cause new pods to be created. The first pod (out-0) would have no errors, however but new pods (out-1, out 2..) would keep restarting due to the following error: 
```
Caused by: org.apache.pulsar.client.api.PulsarClientException$ProducerBusyException: 
{"errorMsg":"org.apache.pulsar.broker.service.BrokerServiceException$NamingException: 
Producer with name 'test-producer' is already connected to topic 'persistent://public/default/test-config-topic'",
```

Notice the number of restarts.
![Pasted Graphic 5](https://github.com/user-attachments/assets/5350a21c-b7b8-4ed3-aaaa-27211263f395)


This is because when a `producerName` is set in the configMap, it will try to use the same producerName for all the pods causing there to be multiple producers connected to the same topic with the same name.  As producerName is mainly used for tracing purposes, we implemented this solution as it will ensure the pod names are unique while ensuring it has a meaningful name. 

## Solution
In this PR, we implement an override such that the producerName is always the podName, which eliminates errors for when there are multiple pods whether a producerName is set or not. 

This assumes that the user is using the default setting of a `shared` access mode as having multiple pods requires a shared access mode. This is not configurable regardless through the `confMap`, and therefore we prevent the user from setting a different access mode. 

https://pulsar.apache.org/docs/4.0.x/concepts-clients/#access-mode

## Test cases after implementing changes
#### Single pod, when no producerName is set.

![Pasted Graphic 1](https://github.com/user-attachments/assets/d55ab8ea-9146-4f7c-839d-e3ec3d504181)


#### Multiple pods, no producerName set
![Pasted Graphic 2](https://github.com/user-attachments/assets/380c9481-7640-4082-8093-253b19ebc9a1)

Can see in Pulsar Manager that there are multiple producers, all set to their pod names for one specified topic:
![Pasted Graphic 4](https://github.com/user-attachments/assets/940d43d7-1a2f-47de-bc33-13f8f79e5786)

#### Single pod, a producerName is set:
_Notice the log message acknowledging a producer name is set but it was not used._ 
![image](https://github.com/user-attachments/assets/a1ab016a-f6c2-4cd0-b24b-e5ffe9fb8c66)

#### Multiple pods, producerName is set 
_Notice the log message acknowledging a producer name is set but it was not used._ 
_Additionally, notice that this is the "out-1" pod_
![image](https://github.com/user-attachments/assets/3fd219e9-bf54-439f-8792-d242d5ce43d9)

