### PR TITLE
feat: add configurations and implement simple source

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -5,16 +5,6 @@ metadata:
 spec:
   vertices:
     - name: in
-      source:
-        generator:
-          rpu: 1
-          duration: 1s
-          msgSize: 10
-    - name: p1
-      udf:
-        builtin:
-          name: cat
-    - name: out
       volumes: # Shared between containers that are part of the same pod, useful for sharing configurations
         - name: pulsar-config-volume
           configMap:
@@ -22,8 +12,8 @@ spec:
             items:
               - key: application.yml
                 path: application.yml
-      sink:
-        udsink:
+      source:
+        udsource: 
           container:
             image: apache-pulsar-java:v0.2.0
             args: [ "--spring.config.location=file:/conf/application.yml" ] # Use external configuration file 
@@ -31,6 +21,17 @@ spec:
             volumeMounts:
               - name: pulsar-config-volume
                 mountPath: /conf
+    - name: p1
+      scale:
+        min: 1
+      udf:
+        builtin:
+          name: cat # A built-in UDF which simply cats the message
+    - name: out
+      scale:
+        min: 1
+      sink:
+        log: {}
   edges:
     - from: in
       to: p1

--- a/pulsar-config-map.yaml
+++ b/pulsar-config-map.yaml
@@ -12,8 +12,8 @@ data:
             serviceUrl: "pulsar://host.docker.internal:6650"
         producer:
           enabled: false
-          producerConfig: # see here for all configurations: https://pulsar.apache.org/reference/#/4.0.x/client/client-configuration-producer
-            topicName: "test-config-topic" 
-            sendTimeoutMs: 2000
         consumer: 
           enabled: true
+
+
+

--- a/pulsar-config-map.yaml
+++ b/pulsar-config-map.yaml
@@ -11,9 +11,9 @@ data:
           clientConfig:
             serviceUrl: "pulsar://host.docker.internal:6650"
         producer:
-          enabled: true
+          enabled: false
           producerConfig: # see here for all configurations: https://pulsar.apache.org/reference/#/4.0.x/client/client-configuration-producer
             topicName: "test-config-topic" 
             sendTimeoutMs: 2000
         consumer: 
-          enabled: false
+          enabled: true

--- a/pulsar-config-map.yaml
+++ b/pulsar-config-map.yaml
@@ -6,10 +6,14 @@ data:
   application.yml: |
     spring:
       pulsar:
+      
         client: # see here for all configurations: https://pulsar.apache.org/reference/#/4.0.x/client/client-configuration-client
           clientConfig:
             serviceUrl: "pulsar://host.docker.internal:6650"
         producer:
+          enabled: true
           producerConfig: # see here for all configurations: https://pulsar.apache.org/reference/#/4.0.x/client/client-configuration-producer
             topicName: "test-config-topic" 
             sendTimeoutMs: 2000
+        consumer: 
+          enabled: false

--- a/src/main/java/io/numaproj/pulsar/config/PulsarProducerProperties.java
+++ b/src/main/java/io/numaproj/pulsar/config/PulsarProducerProperties.java
@@ -2,6 +2,8 @@ package io.numaproj.pulsar.config;
 
 import lombok.Getter;
 import lombok.Setter;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,7 +13,7 @@ import java.util.Map;
 @Getter
 @Setter
 @Configuration
-@ConfigurationProperties(prefix = "spring.pulsar.producer")
+@ConditionalOnProperty(prefix = "spring.pulsar.producer", name = "enabled", havingValue = "true")
 public class PulsarProducerProperties {
     private Map<String, Object> producerConfig = new HashMap<>(); // Default to an empty map
 }

--- a/src/main/java/io/numaproj/pulsar/consumer/SimpleSource.java
+++ b/src/main/java/io/numaproj/pulsar/consumer/SimpleSource.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * This component is conditionally loaded only when consumer properties are
  * enabled.
- * For example, when 'spring.pulsar.consumer.enabled' is set to true.
+ * For example, when 'spring.pulsar.consumer.enabled' is set to truÅe.
  */
 @Slf4j
 @Component

--- a/src/main/java/io/numaproj/pulsar/consumer/SimpleSource.java
+++ b/src/main/java/io/numaproj/pulsar/consumer/SimpleSource.java
@@ -1,0 +1,100 @@
+package io.numaproj.pulsar.consumer;
+
+import com.google.common.primitives.Longs;
+import io.numaproj.numaflow.sourcer.AckRequest;
+import io.numaproj.numaflow.sourcer.Message;
+import io.numaproj.numaflow.sourcer.Offset;
+import io.numaproj.numaflow.sourcer.OutputObserver;
+import io.numaproj.numaflow.sourcer.ReadRequest;
+import io.numaproj.numaflow.sourcer.Server;
+import io.numaproj.numaflow.sourcer.Sourcer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * SimpleSource is a simple implementation of Sourcer.
+ * It generates messages with increasing offsets.
+ * Keeps track of the messages read and acknowledges them when ack is called.
+ *
+ * This component is conditionally loaded only when consumer properties are
+ * enabled.
+ * For example, when 'spring.pulsar.consumer.enabled' is set to true.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "spring.pulsar.consumer", name = "enabled", havingValue = "true")
+public class SimpleSource extends Sourcer {
+
+    private final Map<Long, Boolean> messages = new ConcurrentHashMap<>();
+    private long readIndex = 0;
+    private Server server;
+
+    @PostConstruct // starts server automatically when the Spring context initializes
+    public void startServer() throws Exception {
+        server = new Server(this);
+        server.start();
+        server.awaitTermination();
+    }
+
+    @Override
+    public void read(ReadRequest request, OutputObserver observer) {
+        long startTime = System.currentTimeMillis();
+
+        // if there are messages not acknowledged, return
+        if (!messages.isEmpty()) {
+            return;
+        }
+
+        for (int i = 0; i < request.getCount(); i++) {
+            if (System.currentTimeMillis() - startTime > request.getTimeout().toMillis()) {
+                return;
+            }
+
+            Map<String, String> headers = new HashMap<>();
+            headers.put("x-txn-id", UUID.randomUUID().toString());
+
+            // create a message with increasing offset
+            Offset offset = new Offset(Longs.toByteArray(readIndex));
+            Message message = new Message(
+                    Long.toString(readIndex).getBytes(),
+                    offset,
+                    Instant.now(),
+                    headers);
+
+            // send the message to the observer
+            observer.send(message);
+            // keep track of the messages read and not acknowledged
+            messages.put(readIndex, true);
+            readIndex += 1;
+        }
+    }
+
+    @Override
+    public void ack(AckRequest request) {
+        request.getOffsets().forEach(offset -> {
+            Long decodedOffset = Longs.fromByteArray(offset.getValue());
+            // remove the acknowledged messages from the map
+            messages.remove(decodedOffset);
+        });
+    }
+
+    @Override
+    public long getPending() {
+        // number of messages not acknowledged yet
+        return messages.size();
+    }
+
+    @Override
+    public List<Integer> getPartitions() {
+        return Sourcer.defaultPartitions();
+    }
+}

--- a/src/main/java/io/numaproj/pulsar/consumer/SimpleSource.java
+++ b/src/main/java/io/numaproj/pulsar/consumer/SimpleSource.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * This component is conditionally loaded only when consumer properties are
  * enabled.
- * For example, when 'spring.pulsar.consumer.enabled' is set to truÅe.
+ * For example, when 'spring.pulsar.consumer.enabled' is set to true.
  */
 @Slf4j
 @Component

--- a/src/main/java/io/numaproj/pulsar/producer/PulsarConfig.java
+++ b/src/main/java/io/numaproj/pulsar/producer/PulsarConfig.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 import org.apache.pulsar.client.api.Producer;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -39,6 +40,7 @@ public class PulsarConfig {
     }
 
     @Bean
+    @ConditionalOnProperty(prefix = "spring.pulsar.producer", name = "enabled", havingValue = "true", matchIfMissing = false)
     public Producer<byte[]> pulsarProducer(PulsarClient pulsarClient, PulsarProducerProperties pulsarProducerProperties)
             throws Exception {
         String podName = env.getProperty("NUMAFLOW_POD", "pod-" + UUID.randomUUID());


### PR DESCRIPTION
- Add conditional configurations to either enable the producer OR the consumer 
- Ensures that when the consumer is enabled, and the producer is disabled, that a producer is not created. A more elegant solution can be implemented later when we used the ConfigMap to load properties for the consumer. 
- Add simple source (without sending anything to pulsar)
- Create pipeline for a UDSource