### PR TITLE
test: add unit test for read and ack in source, add ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+    - name: Build with Maven, run unit tests and the coverage check
+      run: mvn clean install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,5 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
-    - name: Build with Maven, run unit tests and the coverage check
+    - name: Build with Maven, run unit tests
       run: mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,23 @@
                 </configuration>
             </plugin>
             <plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-surefire-plugin</artifactId>
+			<version>2.22.0</version>
+			<dependencies>
+				<dependency>
+					<groupId>org.apache.maven.surefire</groupId>
+					<artifactId>surefire-junit4</artifactId>
+					<version>2.22.0</version>
+				</dependency>
+			</dependencies>
+			<configuration>
+				<includes>
+					<include>**/*.java</include>
+				</includes>
+			</configuration>
+		</plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>3.3.0</version>

--- a/src/test/java/io/numaproj/pulsar/config/PulsarConsumerPropertiesTest.java
+++ b/src/test/java/io/numaproj/pulsar/config/PulsarConsumerPropertiesTest.java
@@ -1,0 +1,57 @@
+package io.numaproj.pulsar.config;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class PulsarConsumerPropertiesTest {
+
+    @Test
+    public void testInitTransformsTopicNamesProperty() {
+        // Prepare a properties instance with a string value for topicNames
+        PulsarConsumerProperties properties = new PulsarConsumerProperties();
+        Map<String, Object> config = new HashMap<>();
+        String topic = "my-test-topic";
+        config.put("topicNames", topic);
+        // Also add another unrelated property
+        config.put("otherKey", "otherValue");
+        properties.setConsumerConfig(config);
+
+        // When init is called, it should convert the topicNames value to a Set
+        properties.init();
+
+        // Verify that topicNames is now a Set containing the original string
+        Object topicNamesObj = properties.getConsumerConfig().get("topicNames");
+        assertNotNull("topicNames should not be null after init", topicNamesObj);
+        assertTrue("topicNames should be of type Set", topicNamesObj instanceof Set);
+
+        Set<?> topicNamesSet = (Set<?>) topicNamesObj;
+        assertEquals("The topicNames set should contain one item", 1, topicNamesSet.size());
+        assertTrue("The topicNames set should contain the initial topic", topicNamesSet.contains(topic));
+
+        // Ensure that unrelated properties remain unchanged
+        assertEquals("otherKey property should remain unchanged", "otherValue",
+                properties.getConsumerConfig().get("otherKey"));
+    }
+
+    @Test
+    public void testInitWithoutTopicNames() {
+        // Prepare a properties instance without topicNames key
+        PulsarConsumerProperties properties = new PulsarConsumerProperties();
+        Map<String, Object> config = new HashMap<>();
+        config.put("someKey", "someValue");
+        properties.setConsumerConfig(config);
+
+        // Call init should not modify the properties map for keys that don't exist.
+        properties.init();
+
+        // The same key should exist with the original value
+        assertEquals("someValue", properties.getConsumerConfig().get("someKey"));
+        // There should be no topicNames key added by init
+        assertFalse("topicNames key should not be added if not present",
+                properties.getConsumerConfig().containsKey("topicNames"));
+    }
+}

--- a/src/test/java/io/numaproj/pulsar/config/PulsarConsumerPropertiesTest.java
+++ b/src/test/java/io/numaproj/pulsar/config/PulsarConsumerPropertiesTest.java
@@ -36,22 +36,4 @@ public class PulsarConsumerPropertiesTest {
         assertEquals("otherKey property should remain unchanged", "otherValue",
                 properties.getConsumerConfig().get("otherKey"));
     }
-
-    @Test
-    public void testInitWithoutTopicNames() {
-        // Prepare a properties instance without topicNames key
-        PulsarConsumerProperties properties = new PulsarConsumerProperties();
-        Map<String, Object> config = new HashMap<>();
-        config.put("someKey", "someValue");
-        properties.setConsumerConfig(config);
-
-        // Call init should not modify the properties map for keys that don't exist.
-        properties.init();
-
-        // The same key should exist with the original value
-        assertEquals("someValue", properties.getConsumerConfig().get("someKey"));
-        // There should be no topicNames key added by init
-        assertFalse("topicNames key should not be added if not present",
-                properties.getConsumerConfig().containsKey("topicNames"));
-    }
 }

--- a/src/test/java/io/numaproj/pulsar/consumer/PulsarConsumerManagerTest.java
+++ b/src/test/java/io/numaproj/pulsar/consumer/PulsarConsumerManagerTest.java
@@ -1,0 +1,163 @@
+package io.numaproj.pulsar.consumer;
+
+import io.numaproj.pulsar.config.PulsarConsumerProperties;
+import org.apache.pulsar.client.api.BatchReceivePolicy;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.*;
+
+public class PulsarConsumerManagerTest {
+
+    private PulsarConsumerManager manager;
+    private PulsarConsumerProperties consumerProperties;
+    private PulsarClient mockPulsarClient;
+    private ConsumerBuilder<byte[]> mockConsumerBuilder;
+    private Consumer<byte[]> mockConsumer;
+
+    @Before
+    public void setUp() {
+        // Create a simple consumer properties object with a dummy config
+        consumerProperties = new PulsarConsumerProperties();
+        Map<String, Object> config = new HashMap<>();
+        config.put("dummyKey", "dummyValue");
+        consumerProperties.setConsumerConfig(config);
+
+        // Instantiate the manager and inject dependencies using ReflectionTestUtils
+        manager = new PulsarConsumerManager();
+        ReflectionTestUtils.setField(manager, "pulsarConsumerProperties", consumerProperties);
+
+        // Create mocks for PulsarClient and the ConsumerBuilder chain
+        mockPulsarClient = mock(PulsarClient.class);
+        mockConsumerBuilder = mock(ConsumerBuilder.class);
+        mockConsumer = mock(Consumer.class);
+        ReflectionTestUtils.setField(manager, "pulsarClient", mockPulsarClient);
+    }
+
+    @After
+    public void tearDown() {
+        manager = null;
+        consumerProperties = null;
+        mockPulsarClient = null;
+        mockConsumerBuilder = null;
+        mockConsumer = null;
+    }
+
+    @Test
+    public void getOrCreateConsumer_createsNewConsumer() throws PulsarClientException {
+        // Set up the chaining calls on the ConsumerBuilder mock
+        when(mockPulsarClient.newConsumer(Schema.BYTES)).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.loadConf(anyMap())).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.batchReceivePolicy(any(BatchReceivePolicy.class))).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.subscriptionType(SubscriptionType.Shared)).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.subscribe()).thenReturn(mockConsumer);
+
+        // Call getOrCreateConsumer for the first time so it creates a new consumer
+        Consumer<byte[]> firstConsumer = manager.getOrCreateConsumer(10L, 1000L);
+        assertNotNull("A consumer should be created", firstConsumer);
+        assertEquals("The returned consumer should be the mock consumer", mockConsumer, firstConsumer);
+
+        // Call again and verify that it returns the same instance (i.e.,
+        // builder.subscribe() is not called again)
+        Consumer<byte[]> secondConsumer = manager.getOrCreateConsumer(10L, 1000L);
+        assertEquals("Should return the same consumer instance", firstConsumer, secondConsumer);
+
+        // Verify that newConsumer(...) and subscribe() are invoked only once
+        verify(mockPulsarClient, times(1)).newConsumer(Schema.BYTES);
+        verify(mockConsumerBuilder, times(1)).subscribe();
+
+        // Capture loaded configuration to verify that consumerProperties configuration
+        // is passed
+        ArgumentCaptor<Map> configCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(mockConsumerBuilder).loadConf(configCaptor.capture());
+        Map loadedConfig = configCaptor.getValue();
+        assertEquals("dummyValue", loadedConfig.get("dummyKey"));
+
+        // Also validate the batch policy: maxNumMessages set to 10 and timeout 1000ms.
+        ArgumentCaptor<BatchReceivePolicy> batchPolicyCaptor = ArgumentCaptor.forClass(BatchReceivePolicy.class);
+        verify(mockConsumerBuilder).batchReceivePolicy(batchPolicyCaptor.capture());
+        BatchReceivePolicy builtPolicy = batchPolicyCaptor.getValue();
+        // We can't directly get the values from BatchReceivePolicy,
+        // but we verify that the builder was called with a policy.
+        assertNotNull("BatchReceivePolicy should be set", builtPolicy);
+    }
+
+    @Test
+    public void cleanup_closesConsumerAndClient() throws PulsarClientException {
+        // Set up the Consumer to be non-null so that cleanup closes it
+        when(mockPulsarClient.newConsumer(Schema.BYTES)).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.loadConf(anyMap())).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.batchReceivePolicy(any(BatchReceivePolicy.class))).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.subscriptionType(SubscriptionType.Shared)).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.subscribe()).thenReturn(mockConsumer);
+
+        // Create the consumer via getOrCreateConsumer
+        Consumer<byte[]> createdConsumer = manager.getOrCreateConsumer(5L, 500L);
+        assertNotNull(createdConsumer);
+
+        // Call cleanup and verify that close() is called on both consumer and client
+        manager.cleanup();
+        verify(createdConsumer, times(1)).close();
+        verify(mockPulsarClient, times(1)).close();
+    }
+
+    @Test
+    public void cleanup_whenConsumerIsNull() throws PulsarClientException {
+        // Set currentConsumer to null explicitly
+        ReflectionTestUtils.setField(manager, "currentConsumer", null);
+
+        // Call cleanup, expecting that the client is closed even if consumer is null
+        manager.cleanup();
+        verify(mockPulsarClient, times(1)).close();
+    }
+
+    @Test
+    public void cleanup_consumerCloseThrowsException() throws PulsarClientException {
+        // Setup: create a consumer and simulate an exception on closing consumer
+        when(mockPulsarClient.newConsumer(Schema.BYTES)).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.loadConf(anyMap())).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.batchReceivePolicy(any(BatchReceivePolicy.class))).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.subscriptionType(SubscriptionType.Shared)).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.subscribe()).thenReturn(mockConsumer);
+
+        Consumer<byte[]> createdConsumer = manager.getOrCreateConsumer(3L, 300L);
+        assertNotNull(createdConsumer);
+
+        // Simulate exception when consumer.close() is invoked
+        doThrow(new PulsarClientException("Consumer close failed")).when(createdConsumer).close();
+
+        // Call cleanup; should catch the exception and still proceed to close the
+        // client
+        manager.cleanup();
+        verify(createdConsumer, times(1)).close();
+        verify(mockPulsarClient, times(1)).close();
+    }
+
+    @Test
+    public void cleanup_clientCloseThrowsException() throws PulsarClientException {
+        // Set up consumer as null so that only client.close() is invoked during cleanup
+        ReflectionTestUtils.setField(manager, "currentConsumer", null);
+
+        // Simulate exception when pulsarClient.close() is invoked
+        doThrow(new PulsarClientException("Client close failed")).when(mockPulsarClient).close();
+
+        // Call cleanup; should catch the exception
+        manager.cleanup();
+        verify(mockPulsarClient, times(1)).close();
+    }
+}

--- a/src/test/java/io/numaproj/pulsar/consumer/PulsarSourceTest.java
+++ b/src/test/java/io/numaproj/pulsar/consumer/PulsarSourceTest.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 public class PulsarSourceTest {
@@ -156,7 +158,7 @@ public class PulsarSourceTest {
         assertEquals("Hello", new String(sentMessages.get(0).getValue(), StandardCharsets.UTF_8));
         assertEquals("World", new String(sentMessages.get(1).getValue(), StandardCharsets.UTF_8));
 
-        // Confirm  messages are tracked for ack.
+        // Confirm messages are tracked for ack.
         // The keys should be "msg1" and "msg2"
         java.util.Map<String, ?> ackMap = (java.util.Map<String, ?>) ReflectionTestUtils.getField(pulsarSource,
                 "messagesToAck");
@@ -218,10 +220,12 @@ public class PulsarSourceTest {
             }
         };
 
-        // Call ack. Since there is no matching message, nothing should happen.
         pulsarSource.ack(ackRequest);
 
-        // Verify no interactions with consumer are performed.
-        verify(consumerManagerMock, never()).getOrCreateConsumer(anyLong(), anyLong());
+        try {
+            verify(consumerManagerMock, never()).getOrCreateConsumer(anyLong(), anyLong());
+        } catch (PulsarClientException e) {
+            fail("Unexpected exception during verification: " + e.getMessage());
+        }
     }
 }

--- a/src/test/java/io/numaproj/pulsar/consumer/PulsarSourceTest.java
+++ b/src/test/java/io/numaproj/pulsar/consumer/PulsarSourceTest.java
@@ -56,7 +56,7 @@ public class PulsarSourceTest {
      * Test that when messagesToAck is not empty, the read method returns early.
      */
     @Test
-    public void testReadWhenMessagesToAckNotEmpty() {
+    public void readWhenMessagesToAckNotEmpty() {
         try {
             // Prepopulate the messagesToAck map using reflection access.
             // We simulate that there is already one message waiting for ack.
@@ -92,7 +92,7 @@ public class PulsarSourceTest {
      * Test the normal behavior of read when batchReceive returns no messages.
      */
     @Test
-    public void testReadWhenNoMessagesReceived() {
+    public void readWhenNoMessagesReceived() {
         try {
             // Reset the messagesToAck map to ensure it is empty.
             @SuppressWarnings("unchecked")
@@ -125,7 +125,7 @@ public class PulsarSourceTest {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testReadWhenMessagesReceived() {
+    public void readWhenMessagesReceived() {
         try {
             // Clear messagesToAck
             java.util.Map<String, ?> messagesToAck = (java.util.Map<String, ?>) ReflectionTestUtils
@@ -188,7 +188,7 @@ public class PulsarSourceTest {
      * Test the ack method when there is a message to be acknowledged.
      */
     @Test
-    public void testAckSuccessful() {
+    public void ackSuccessful() {
         try {
             // Create a dummy message to acknowledge.
             org.apache.pulsar.client.api.Message<byte[]> msg = mock(org.apache.pulsar.client.api.Message.class);
@@ -230,7 +230,7 @@ public class PulsarSourceTest {
      * Test the ack method when the offset does not exist in messagesToAck.
      */
     @Test
-    public void testAckNoMatchingMessage() throws PulsarClientException {
+    public void ackNoMatchingMessage() throws PulsarClientException {
         // Ensure messagesToAck is empty.
         java.util.Map<String, org.apache.pulsar.client.api.Message<byte[]>> messagesToAck = (java.util.Map<String, org.apache.pulsar.client.api.Message<byte[]>>) ReflectionTestUtils
                 .getField(pulsarSource, "messagesToAck");

--- a/src/test/java/io/numaproj/pulsar/consumer/PulsarSourceTest.java
+++ b/src/test/java/io/numaproj/pulsar/consumer/PulsarSourceTest.java
@@ -207,7 +207,7 @@ public class PulsarSourceTest {
      * Test the ack method when the offset does not exist in messagesToAck.
      */
     @Test
-    public void testAckNoMatchingMessage() throws PulsarClientException {
+    public void testAckNoMatchingMessage() {
         // Ensure messagesToAck is empty.
         java.util.Map<String, org.apache.pulsar.client.api.Message<byte[]>> messagesToAck = (java.util.Map<String, org.apache.pulsar.client.api.Message<byte[]>>) ReflectionTestUtils
                 .getField(pulsarSource, "messagesToAck");

--- a/src/test/java/io/numaproj/pulsar/consumer/PulsarSourceTest.java
+++ b/src/test/java/io/numaproj/pulsar/consumer/PulsarSourceTest.java
@@ -1,0 +1,227 @@
+package io.numaproj.pulsar.consumer;
+
+import io.numaproj.numaflow.sourcer.AckRequest;
+import io.numaproj.numaflow.sourcer.Message;
+import io.numaproj.numaflow.sourcer.Offset;
+import io.numaproj.numaflow.sourcer.ReadRequest;
+import io.numaproj.numaflow.sourcer.OutputObserver;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Messages;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class PulsarSourceTest {
+
+    private PulsarSource pulsarSource;
+    private PulsarConsumerManager consumerManagerMock;
+    private Consumer<byte[]> consumerMock;
+
+    @Before
+    public void setUp() throws PulsarClientException {
+        pulsarSource = new PulsarSource();
+        consumerManagerMock = mock(PulsarConsumerManager.class);
+        consumerMock = mock(Consumer.class);
+        // Inject the mocked PulsarConsumerManager into pulsarSource using
+        // ReflectionTestUtils.
+        ReflectionTestUtils.setField(pulsarSource, "pulsarConsumerManager", consumerManagerMock);
+    }
+
+    @After
+    public void tearDown() {
+        pulsarSource = null;
+        consumerManagerMock = null;
+        consumerMock = null;
+    }
+
+    /**
+     * Test that when messagesToAck is not empty, the read method returns early.
+     */
+    @Test
+    public void testReadWhenMessagesToAckNotEmpty() throws PulsarClientException {
+        // Prepopulate the messagesToAck map using reflection access.
+        // We simulate that there is already one message waiting for ack.
+        String dummyMsgId = "dummyMsgId";
+        // Create a dummy Pulsar message and add it to the map.
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, org.apache.pulsar.client.api.Message<byte[]>> messagesToAck = (java.util.Map<String, org.apache.pulsar.client.api.Message<byte[]>>) ReflectionTestUtils
+                .getField(pulsarSource, "messagesToAck");
+        @SuppressWarnings("unchecked")
+        org.apache.pulsar.client.api.Message<byte[]> dummyMessage = mock(org.apache.pulsar.client.api.Message.class);
+        when(dummyMessage.getMessageId()).thenReturn(mock(MessageId.class));
+        messagesToAck.put(dummyMsgId, dummyMessage);
+
+        // Create mocks for ReadRequest and OutputObserver.
+        ReadRequest readRequest = mock(ReadRequest.class);
+        when(readRequest.getCount()).thenReturn(10L);
+        when(readRequest.getTimeout()).thenReturn(Duration.ofMillis(1000));
+        OutputObserver observer = mock(OutputObserver.class);
+
+        // Call read.
+        pulsarSource.read(readRequest, observer);
+        // Since messagesToAck is not empty, read should return early and not call
+        // consumerManager.getOrCreateConsumer.
+        verify(consumerManagerMock, never()).getOrCreateConsumer(anyLong(), anyLong());
+        verify(observer, never()).send(any(Message.class));
+    }
+
+    /**
+     * Test the normal behavior of read when batchReceive returns no messages.
+     */
+    @Test
+    public void testReadWhenNoMessagesReceived() throws PulsarClientException {
+        // Reset the messagesToAck map to ensure it is empty.
+        java.util.Map<String, ?> messagesToAck = (java.util.Map<String, ?>) ReflectionTestUtils.getField(pulsarSource,
+                "messagesToAck");
+        messagesToAck.clear();
+
+        // Stub the consumerManager to return the consumerMock.
+        when(consumerManagerMock.getOrCreateConsumer(10L, 1000L)).thenReturn(consumerMock);
+        // Simulate batchReceive returning null.
+        when(consumerMock.batchReceive()).thenReturn(null);
+
+        ReadRequest readRequest = mock(ReadRequest.class);
+        when(readRequest.getCount()).thenReturn(10L);
+        when(readRequest.getTimeout()).thenReturn(Duration.ofMillis(1000));
+
+        OutputObserver observer = mock(OutputObserver.class);
+
+        pulsarSource.read(readRequest, observer);
+
+        // Verify that observer.send is never called.
+        verify(observer, never()).send(any(Message.class));
+    }
+
+    /**
+     * Test the normal behavior of read when batchReceive returns some messages.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testReadWhenMessagesReceived() throws PulsarClientException {
+        // Clear messagesToAck
+        java.util.Map<String, ?> messagesToAck = (java.util.Map<String, ?>) ReflectionTestUtils.getField(pulsarSource,
+                "messagesToAck");
+        messagesToAck.clear();
+
+        // Setup a fake batch of messages
+        org.apache.pulsar.client.api.Message<byte[]> msg1 = mock(org.apache.pulsar.client.api.Message.class);
+        org.apache.pulsar.client.api.Message<byte[]> msg2 = mock(org.apache.pulsar.client.api.Message.class);
+
+        // Stub message ids and values.
+        MessageId msgId1 = mock(MessageId.class);
+        MessageId msgId2 = mock(MessageId.class);
+        when(msgId1.toString()).thenReturn("msg1");
+        when(msgId2.toString()).thenReturn("msg2");
+        when(msg1.getMessageId()).thenReturn(msgId1);
+        when(msg2.getMessageId()).thenReturn(msgId2);
+        when(msg1.getValue()).thenReturn("Hello".getBytes(StandardCharsets.UTF_8));
+        when(msg2.getValue()).thenReturn("World".getBytes(StandardCharsets.UTF_8));
+
+        // Create a fake Messages<byte[]> object
+        Messages<byte[]> messages = mock(Messages.class);
+        when(messages.size()).thenReturn(2);
+        java.util.List<org.apache.pulsar.client.api.Message<byte[]>> messageList = Arrays.asList(msg1, msg2);
+        when(messages.iterator()).thenReturn(messageList.iterator());
+
+        // Stub consumerManager and consumer behavior.
+        when(consumerManagerMock.getOrCreateConsumer(10L, 1000L)).thenReturn(consumerMock);
+        when(consumerMock.batchReceive()).thenReturn(messages);
+
+        // Create a fake ReadRequest and OutputObserver.
+        ReadRequest readRequest = mock(ReadRequest.class);
+        when(readRequest.getCount()).thenReturn(10L);
+        when(readRequest.getTimeout()).thenReturn(Duration.ofMillis(1000));
+        OutputObserver observer = mock(OutputObserver.class);
+
+        pulsarSource.read(readRequest, observer);
+
+        // Verify that observer.send is called for each received message.
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(observer, times(2)).send(messageCaptor.capture());
+        java.util.List<Message> sentMessages = messageCaptor.getAllValues();
+        assertEquals(2, sentMessages.size());
+        // Validate contents of messages using getValue() instead of getPayload()
+        assertEquals("Hello", new String(sentMessages.get(0).getValue(), StandardCharsets.UTF_8));
+        assertEquals("World", new String(sentMessages.get(1).getValue(), StandardCharsets.UTF_8));
+
+        // Confirm  messages are tracked for ack.
+        // The keys should be "msg1" and "msg2"
+        java.util.Map<String, ?> ackMap = (java.util.Map<String, ?>) ReflectionTestUtils.getField(pulsarSource,
+                "messagesToAck");
+        assertTrue(ackMap.containsKey("msg1"));
+        assertTrue(ackMap.containsKey("msg2"));
+    }
+
+    /**
+     * Test the ack method when there is a message to be acknowledged.
+     */
+    @Test
+    public void testAckSuccessful() throws PulsarClientException {
+        // Create a dummy message to acknowledge.
+        org.apache.pulsar.client.api.Message<byte[]> msg = mock(org.apache.pulsar.client.api.Message.class);
+        MessageId msgId = mock(MessageId.class);
+        when(msgId.toString()).thenReturn("ackMsg");
+        when(msg.getMessageId()).thenReturn(msgId);
+        when(msg.getValue()).thenReturn("AckPayload".getBytes(StandardCharsets.UTF_8));
+
+        // Insert the dummy message into the messagesToAck map.
+        java.util.Map<String, org.apache.pulsar.client.api.Message<byte[]>> messagesToAck = (java.util.Map<String, org.apache.pulsar.client.api.Message<byte[]>>) ReflectionTestUtils
+                .getField(pulsarSource, "messagesToAck");
+        messagesToAck.clear();
+        messagesToAck.put("ackMsg", msg);
+
+        // Stub consumerManager to return consumerMock for the ack call.
+        when(consumerManagerMock.getOrCreateConsumer(0, 0)).thenReturn(consumerMock);
+
+        // Create a fake AckRequest with an offset corresponding to the message id.
+        AckRequest ackRequest = new AckRequest() {
+            @Override
+            public java.util.List<Offset> getOffsets() {
+                return Collections.singletonList(new Offset("ackMsg".getBytes(StandardCharsets.UTF_8)));
+            }
+        };
+
+        pulsarSource.ack(ackRequest);
+
+        // Verify that consumer.acknowledge is called on the message.
+        verify(consumerMock, times(1)).acknowledge(msg);
+        // Verify that the messagesToAck map is now empty.
+        assertFalse(messagesToAck.containsKey("ackMsg"));
+    }
+
+    /**
+     * Test the ack method when the offset does not exist in messagesToAck.
+     */
+    @Test
+    public void testAckNoMatchingMessage() throws PulsarClientException {
+        // Ensure messagesToAck is empty.
+        java.util.Map<String, org.apache.pulsar.client.api.Message<byte[]>> messagesToAck = (java.util.Map<String, org.apache.pulsar.client.api.Message<byte[]>>) ReflectionTestUtils
+                .getField(pulsarSource, "messagesToAck");
+        messagesToAck.clear();
+
+        AckRequest ackRequest = new AckRequest() {
+            @Override
+            public java.util.List<Offset> getOffsets() {
+                return Collections.singletonList(new Offset("nonExistentMsg".getBytes(StandardCharsets.UTF_8)));
+            }
+        };
+
+        // Call ack. Since there is no matching message, nothing should happen.
+        pulsarSource.ack(ackRequest);
+
+        // Verify no interactions with consumer are performed.
+        verify(consumerManagerMock, never()).getOrCreateConsumer(anyLong(), anyLong());
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for the PulsarConsumerManager, PulsarSource, and verifies that the the init method in PulsarConsumerProperties turns the topicName into a set. 

A plugin is also added to allow for tests to be run when built.

To see the CI working: https://github.com/jacque1ine/apache-pulsar-java/pull/2
