### PR TITLE
feat: pending with hardcoded service URL

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -4,11 +4,11 @@ metadata:
   name: simple-pipeline
 spec:
   limits: 
-    readBatchSize: 6
+    readBatchSize: 1
   vertices:
     - name: in
       scale:
-        min: 2
+        min: 1
       volumes: # Shared between containers that are part of the same pod, useful for sharing configurations
         - name: pulsar-config-volume
           configMap:

--- a/pulsar-config-map.yaml
+++ b/pulsar-config-map.yaml
@@ -16,7 +16,6 @@ data:
           enabled: true
           consumerConfig: 
             topicNames: "marchtwelve"
-            subscriptionName: "sub"
 
 
 

--- a/pulsar-config-map.yaml
+++ b/pulsar-config-map.yaml
@@ -15,7 +15,7 @@ data:
         consumer: 
           enabled: true
           consumerConfig: 
-            topicNames: "marchten"
+            topicNames: "marchtwelve"
             subscriptionName: "sub"
 
 

--- a/src/main/java/io/numaproj/pulsar/config/PulsarConfig.java
+++ b/src/main/java/io/numaproj/pulsar/config/PulsarConfig.java
@@ -3,6 +3,9 @@ package io.numaproj.pulsar.config;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import java.net.MalformedURLException;
 
 import java.util.Map;
 import java.util.UUID;
@@ -56,5 +59,15 @@ public class PulsarConfig {
         return pulsarClient.newProducer(Schema.BYTES)
                 .loadConf(producerConfig)
                 .create();
+    }
+
+    @Bean
+    public PulsarAdmin pulsarAdmin(PulsarClientProperties pulsarClientProperties) throws PulsarClientException {
+        // String serviceUrl = (String)
+        // pulsarClientProperties.getClientConfig().get("serviceUrl");
+        return PulsarAdmin.builder()
+                .serviceHttpUrl("http://host.docker.internal:8080/")
+                // .authentication(...) if needed
+                .build();
     }
 }

--- a/src/main/java/io/numaproj/pulsar/config/PulsarConfig.java
+++ b/src/main/java/io/numaproj/pulsar/config/PulsarConfig.java
@@ -63,8 +63,6 @@ public class PulsarConfig {
 
     @Bean
     public PulsarAdmin pulsarAdmin(PulsarClientProperties pulsarClientProperties) throws PulsarClientException {
-        // String serviceUrl = (String)
-        // pulsarClientProperties.getClientConfig().get("serviceUrl");
         return PulsarAdmin.builder()
                 .serviceHttpUrl("http://host.docker.internal:8080/")
                 // .authentication(...) if needed

--- a/src/main/java/io/numaproj/pulsar/config/PulsarConsumerProperties.java
+++ b/src/main/java/io/numaproj/pulsar/config/PulsarConsumerProperties.java
@@ -20,6 +20,9 @@ import java.util.Map;
 @ConfigurationProperties(prefix = "spring.pulsar.consumer")
 @Slf4j
 public class PulsarConsumerProperties {
+
+    private static final String DEFAULT_SUBSCRIPTION_NAME = "sub";
+    
     private Map<String, Object> consumerConfig = new HashMap<>(); // Default to an empty map
 
     @PostConstruct
@@ -36,8 +39,8 @@ public class PulsarConsumerProperties {
         // If 'subscriptionName' not present, provide a default
         String subscriptionNameKey = "subscriptionName";
         if (!consumerConfig.containsKey(subscriptionNameKey)) {
-            consumerConfig.put(subscriptionNameKey, "sub");
-            log.info("No subscriptionName provided. Setting default: 'sub'");
+            consumerConfig.put(subscriptionNameKey, DEFAULT_SUBSCRIPTION_NAME);
+            log.info("No subscriptionName provided. Setting default: '{}'", DEFAULT_SUBSCRIPTION_NAME);
         } else {
             log.info("subscriptionName was already set, leaving as-is.");
         }

--- a/src/main/java/io/numaproj/pulsar/config/PulsarConsumerProperties.java
+++ b/src/main/java/io/numaproj/pulsar/config/PulsarConsumerProperties.java
@@ -25,12 +25,23 @@ public class PulsarConsumerProperties {
     @PostConstruct
     public void init() {
         // Pulsar expects topicNames to be type set, but the configMap accepts a string
-        if (consumerConfig.containsKey("topicNames")) {
-            String topicName = (String) consumerConfig.remove("topicNames");
+        String topicNameKey = "topicNames";
+        if (consumerConfig.containsKey(topicNameKey)) {
+            String topicName = (String) consumerConfig.remove(topicNameKey);
             Set<String> topicNames = new HashSet<>();
             topicNames.add(topicName);
-            consumerConfig.put("topicNames", topicNames);
+            consumerConfig.put(topicNameKey, topicNames);
         }
-        log.info("Consumer Config: " + consumerConfig);
+
+        // If 'subscriptionName' not present, provide a default
+        String subscriptionNameKey = "subscriptionName";
+        if (!consumerConfig.containsKey(subscriptionNameKey)) {
+            consumerConfig.put(subscriptionNameKey, "sub");
+            log.info("No subscriptionName provided. Setting default: 'sub'");
+        } else {
+            log.info("subscriptionName was already set, leaving as-is.");
+        }
+
+        log.info("Consumer Config: {}", consumerConfig);
     }
 }

--- a/src/main/java/io/numaproj/pulsar/consumer/PulsarSource.java
+++ b/src/main/java/io/numaproj/pulsar/consumer/PulsarSource.java
@@ -11,7 +11,6 @@ import io.numaproj.pulsar.config.PulsarConsumerProperties;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerStats;
 import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -135,31 +134,23 @@ public class PulsarSource extends Sourcer {
         }
     }
 
-    // @Override
-    // // public long getPending() {
-    // // // TO DO: Currently this is received but not acked. Should be num messages
-    // in
-    // // // backlog
-    // // return messagesToAck.size();
-    // // }
     @Override
     public long getPending() {
         try {
             // If changing to support multiple topics, need to update this
             Set<String> topicNames = (Set<String>) pulsarConsumerProperties.getConsumerConfig().get("topicNames");
-            String topicName = (String) topicNames.iterator().next(); 
+            String topicName = (String) topicNames.iterator().next(); // Assumes there is only one topic name in the set
             String subscriptionName = (String) pulsarConsumerProperties.getConsumerConfig().get("subscriptionName");
 
             TopicStats topicStats = pulsarAdmin.topics().getStats(topicName);
             SubscriptionStats subscriptionStats = topicStats.getSubscriptions().get(subscriptionName);
-            log.info("this is the number of messages in the backlog: {}", subscriptionStats.getMsgBacklog());
-
+            // will remove later - used for testing
+            log.info("Number of messages in the backlog: {}", subscriptionStats.getMsgBacklog()); 
             return subscriptionStats.getMsgBacklog();
         } catch (PulsarAdminException e) {
             log.error("Error while fetching admin stats for pending messages", e);
-            // Return a negative value to indicate an error state
+            // Return a negative value to indicate no pending information
             return -1;
-            // the no pending avalaibale thing from the docs?
         }
     }
 

--- a/src/main/java/io/numaproj/pulsar/consumer/PulsarSource.java
+++ b/src/main/java/io/numaproj/pulsar/consumer/PulsarSource.java
@@ -7,11 +7,17 @@ import io.numaproj.numaflow.sourcer.OutputObserver;
 import io.numaproj.numaflow.sourcer.ReadRequest;
 import io.numaproj.numaflow.sourcer.Server;
 import io.numaproj.numaflow.sourcer.Sourcer;
+import io.numaproj.pulsar.config.PulsarConsumerProperties;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerStats;
 import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.policies.data.TopicStats;
+import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -22,6 +28,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Slf4j
 @Component
@@ -35,6 +42,12 @@ public class PulsarSource extends Sourcer {
 
     @Autowired
     private PulsarConsumerManager pulsarConsumerManager;
+
+    @Autowired
+    private PulsarAdmin pulsarAdmin;
+
+    @Autowired
+    PulsarConsumerProperties pulsarConsumerProperties;
 
     @PostConstruct
     public void startServer() throws Exception {
@@ -122,11 +135,32 @@ public class PulsarSource extends Sourcer {
         }
     }
 
+    // @Override
+    // // public long getPending() {
+    // // // TO DO: Currently this is received but not acked. Should be num messages
+    // in
+    // // // backlog
+    // // return messagesToAck.size();
+    // // }
     @Override
     public long getPending() {
-        // TO DO: Currently this is received but not acked. Should be num messages in
-        // backlog
-        return messagesToAck.size();
+        try {
+            // If changing to support multiple topics, need to update this
+            Set<String> topicNames = (Set<String>) pulsarConsumerProperties.getConsumerConfig().get("topicNames");
+            String topicName = (String) topicNames.iterator().next(); 
+            String subscriptionName = (String) pulsarConsumerProperties.getConsumerConfig().get("subscriptionName");
+
+            TopicStats topicStats = pulsarAdmin.topics().getStats(topicName);
+            SubscriptionStats subscriptionStats = topicStats.getSubscriptions().get(subscriptionName);
+            log.info("this is the number of messages in the backlog: {}", subscriptionStats.getMsgBacklog());
+
+            return subscriptionStats.getMsgBacklog();
+        } catch (PulsarAdminException e) {
+            log.error("Error while fetching admin stats for pending messages", e);
+            // Return a negative value to indicate an error state
+            return -1;
+            // the no pending avalaibale thing from the docs?
+        }
     }
 
     @Override


### PR DESCRIPTION
### Description 
This PR implements that getPending message and will make autoscalling work by retrieving the number of messages in the backlog. 

- Implement the getPending method 
- Use the subscription backlog as the total backlog since we are always using the shared subscription type, so the topic backlog is the same as the subscription backlog
![image](https://github.com/user-attachments/assets/a15f4160-2c16-4e32-b4b0-78fd28372c9e)
https://pulsar.apache.org/docs/next/concepts-messaging/#subscriptions
- As seen in the image, each consumer represents each pod
- Since we need to use the subscription name to get the number of messages in the backlog, this PR also implements a default subscription name to ensure that one is always set
- future PRs will implement passing configurations through the configMap

### Testing 
![Pasted Graphic 12](https://github.com/user-attachments/assets/5835f474-217c-4ce9-ae5d-de34259d04e1)
Example of how with a large number of messages in the backlog, more pods would be created