### PR TITLE
fix: partition update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ development/scripts/register-schema/
 
 ### Performance testing generated configs ###
 development/performance-testing/running-configs/
+
+### MkDocs build output ###
+site/
+
+### Generated Javadoc bundled into MkDocs site ###
+docs/apidocs/

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>io.numaproj.numaflow</groupId>
             <artifactId>numaflow-java</artifactId>
-            <version>0.11.0</version>
+            <version>0.12.0</version>
         </dependency>
         <!-- Override transitive Jackson so JsonProperty.isRequired() returns OptBoolean (numaflow expects 2.19+) -->
         <dependency>

--- a/src/main/java/io/numaproj/pulsar/consumer/PulsarSource.java
+++ b/src/main/java/io/numaproj/pulsar/consumer/PulsarSource.java
@@ -25,12 +25,17 @@ import org.apache.pulsar.common.policies.data.SubscriptionStats;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Numaflow user-defined source that reads messages from one or more Pulsar topics.
+ * Supports raw byte[] messages (Schema.BYTES) or schema-validated messages (Schema.AUTO_CONSUME),
+ * selected via PulsarConsumerProperties.useAutoConsumeSchema.
+ * Pulsar message metadata is forwarded to Numaflow as x-pulsar-* headers.
+ */
 @Slf4j
 public class PulsarSource extends Sourcer {
 
@@ -45,18 +50,37 @@ public class PulsarSource extends Sourcer {
     private final PulsarConsumerProperties pulsarConsumerProperties;
     private Server server;
 
+    /**
+     * Creates a new source.
+     *
+     * @param pulsarConsumerManager    factory for the byte-array or GenericRecord consumer
+     * @param pulsarAdmin              admin client used to query topic partitions and backlog
+     * @param pulsarConsumerProperties parsed pulsar.consumer section of the config
+     */
     public PulsarSource(PulsarConsumerManager pulsarConsumerManager, PulsarAdmin pulsarAdmin, PulsarConsumerProperties pulsarConsumerProperties) {
         this.pulsarConsumerManager = pulsarConsumerManager;
         this.pulsarAdmin = pulsarAdmin;
         this.pulsarConsumerProperties = pulsarConsumerProperties;
     }
 
+    /**
+     * Starts the Numaflow gRPC server and blocks until it terminates.
+     *
+     * @throws Exception if the gRPC server fails
+     */
     public void startServer() throws Exception {
         server = new Server(this);
         server.start();
         server.awaitTermination();
     }
 
+    /**
+     * Reads a batch of messages from the configured Pulsar topic(s) and forwards them to Numaflow.
+     * Returns early without reading if the previous batch has not yet been acknowledged.
+     *
+     * @param request  the read request (count and timeout)
+     * @param observer output channel that emits messages back to Numaflow
+     */
     @Override
     public void read(ReadRequest request, OutputObserver observer) {
         if (!messagesToAck.isEmpty()) {
@@ -122,31 +146,11 @@ public class PulsarSource extends Sourcer {
         }
     }
 
-    /**
-     * Extracts the partition index from a Pulsar topic name.
-     * Partitioned topics have the format "persistent://tenant/ns/topic-partition-N".
-     * Returns 0 for non-partitioned topics.
-     */
-    private static int extractPartitionIndex(String topicName) {
-        int idx = topicName.lastIndexOf("-partition-");
-        if (idx < 0) {
-            return 0;
-        }
-        try {
-            return Integer.parseInt(topicName.substring(idx + "-partition-".length()));
-        } catch (NumberFormatException e) {
-            return 0;
-        }
-    }
-
     /** Builds offset and headers, sends the message to the observer, and records it for ack. */
     private void sendMessage(org.apache.pulsar.client.api.Message<?> pMsg, byte[] payloadBytes, OutputObserver observer) {
         String topicMessageIdKey = pMsg.getTopicName() + pMsg.getMessageId().toString();
         byte[] offsetBytes = topicMessageIdKey.getBytes(StandardCharsets.UTF_8);
-        // Offset offset = new Offset(offsetBytes);
-        // Extract partition from Pulsar message topic name
-        int partition = extractPartitionIndex(pMsg.getTopicName());
-        Offset offset = new Offset(offsetBytes, partition);
+        Offset offset = new Offset(offsetBytes);
         Map<String, String> headers = buildHeaders(pMsg);
         observer.send(new Message(payloadBytes, offset, Instant.now(), headers));
         messagesToAck.put(topicMessageIdKey, pMsg);
@@ -187,6 +191,12 @@ public class PulsarSource extends Sourcer {
         return sb.toString();
     }
 
+    /**
+     * Acknowledges all messages delivered in the previous read call.
+     * The ack request offsets must match the messages from the previous read; otherwise the ack is skipped.
+     *
+     * @param request the ack request containing the offsets to acknowledge
+     */
     @Override
     public void ack(AckRequest request) {
         // Offsets are topicName + messageId (same as messagesToAck key).
@@ -247,12 +257,22 @@ public class PulsarSource extends Sourcer {
         return headers;
     }
 
+    /**
+     * Not yet implemented.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public void nack(NackRequest request) {
         // TODO : implement nack logic
         throw new UnsupportedOperationException("Unimplemented method 'nack'");
     }
 
+    /**
+     * Returns the total subscription backlog across all configured topics.
+     *
+     * @return the total number of un-acknowledged messages, or -1 if the admin call fails
+     */
     @Override
     public long getPending() {
         try {
@@ -270,13 +290,6 @@ public class PulsarSource extends Sourcer {
             log.error("Error while fetching admin stats for pending messages", e);
             return -1;
         }
-    }
-
-    /** Returns the effective partition count for a topic (at least 1 for non-partitioned topics). */
-    private int getEffectivePartitionCount(String topicName) throws PulsarAdminException {
-        var metadata = pulsarAdmin.topics().getPartitionedTopicMetadata(topicName);
-        int partitions = (metadata != null) ? metadata.partitions : 0;
-        return Math.max(partitions, 1);
     }
 
     private long getBacklogForTopic(String topicName, String subscriptionName) throws PulsarAdminException {
@@ -303,46 +316,26 @@ public class PulsarSource extends Sourcer {
         return subscriptionStats != null ? subscriptionStats.getMsgBacklog() : 0;
     }
 
+    /**
+     * Returns the partition(s) this source replica is responsible for, which Numaflow uses to route watermarks.
+     * <p>
+     * Pulsar's subscription model dispatches messages across consumers dynamically; with a Shared
+     * subscription any consumer can receive from any topic partition, so there is no stable binding
+     * between a consumer and a specific set of Pulsar partitions to report here. Instead, each
+     * replica of this source reports itself as a single logical partition, mirroring what
+     * Numaflow's upstream Rust Pulsar source does (see {@code numaflow/rust/extns/numaflow-pulsar}).
+     *
+     * @return a singleton list containing this replica's index (from {@code NUMAFLOW_REPLICA})
+     */
     @Override
     public List<Integer> getActivePartitions() {
-        try {
-            Set<String> topicNames = (Set<String>) pulsarConsumerProperties.getConsumerConfig().get("topicNames");
-            List<Integer> partitionIndexes = new ArrayList<>();
-            int globalIndex = 0;
-            for (String topicName : topicNames) {
-                int effectivePartitions = getEffectivePartitionCount(topicName);
-                log.info("Number of partitions reported for topic {}: {}", topicName, effectivePartitions);
-                for (int i = 0; i < effectivePartitions; i++) {
-                    partitionIndexes.add(globalIndex++);
-                }
-            }
-            if (partitionIndexes.isEmpty()) {
-                partitionIndexes.add(0);
-            }
-            log.info("Active partitions: {}", partitionIndexes);
-            return partitionIndexes;
-        } catch (Exception e) {
-            log.error("Error while retrieving partition information. Falling back to default partitions.", e);
-            return defaultPartitions();
-        }
+        return defaultPartitions();
     }
 
-    @Override
-    public Integer getTotalPartitions() {
-        try {
-            Set<String> topicNames = (Set<String>) pulsarConsumerProperties.getConsumerConfig().get("topicNames");
-            int total = 0;
-            for (String topicName : topicNames) {
-                total += getEffectivePartitionCount(topicName);
-            }
-            log.info("Total partitions across {} topic(s): {}", topicNames.size(), total);
-            return total;
-        } catch (PulsarAdminException e) {
-            log.error("Error retrieving total partition count", e);
-            return null;
-        }
-    }
-
+    /**
+     * Closes the underlying Pulsar consumers, client, and admin.
+     * Errors during shutdown are logged rather than thrown.
+     */
     public void cleanup() {
         try {
             pulsarConsumerManager.cleanup();

--- a/src/main/java/io/numaproj/pulsar/consumer/PulsarSource.java
+++ b/src/main/java/io/numaproj/pulsar/consumer/PulsarSource.java
@@ -325,7 +325,9 @@ public class PulsarSource extends Sourcer {
      * replica of this source reports itself as a single logical partition, mirroring what
      * Numaflow's upstream Rust Pulsar source does (see {@code numaflow/rust/extns/numaflow-pulsar}).
      *
-     * @return a singleton list containing this replica's index (from {@code NUMAFLOW_REPLICA})
+     * @return a singleton list containing this replica's index, i.e. the value of the
+     *         {@code NUMAFLOW_REPLICA} environment variable that Numaflow injects into
+     *         each source pod
      */
     @Override
     public List<Integer> getActivePartitions() {

--- a/src/main/java/io/numaproj/pulsar/consumer/PulsarSource.java
+++ b/src/main/java/io/numaproj/pulsar/consumer/PulsarSource.java
@@ -252,6 +252,13 @@ public class PulsarSource extends Sourcer {
         }
     }
 
+    /** Returns the effective partition count for a topic (at least 1 for non-partitioned topics). */
+    private int getEffectivePartitionCount(String topicName) throws PulsarAdminException {
+        var metadata = pulsarAdmin.topics().getPartitionedTopicMetadata(topicName);
+        int partitions = (metadata != null) ? metadata.partitions : 0;
+        return Math.max(partitions, 1);
+    }
+
     private long getBacklogForTopic(String topicName, String subscriptionName) throws PulsarAdminException {
         var metadata = pulsarAdmin.topics().getPartitionedTopicMetadata(topicName);
         int partitionCount = (metadata != null) ? metadata.partitions : 0;
@@ -276,26 +283,15 @@ public class PulsarSource extends Sourcer {
         return subscriptionStats != null ? subscriptionStats.getMsgBacklog() : 0;
     }
 
-    /**
-     * Returns partition indices for this source. Numaflow uses this list to decide which partitions
-     * exist for watermark publishing and scaling (same contract as Kafka-style multi-partition sources).
-     * We expose one integer per Pulsar partition across all configured topics as a flat list [0, 1, 2, ...].
-     */
     @Override
-    public List<Integer> getPartitions() {
+    public List<Integer> getActivePartitions() {
         try {
             Set<String> topicNames = (Set<String>) pulsarConsumerProperties.getConsumerConfig().get("topicNames");
             List<Integer> partitionIndexes = new ArrayList<>();
-            // Assign one integer per partition across all topics (e.g. topic A has 3 partitions -> 0,1,2; topic B has 2 -> 3,4).
             int globalIndex = 0;
             for (String topicName : topicNames) {
-                var metadata = pulsarAdmin.topics().getPartitionedTopicMetadata(topicName);
-                int numPartitions = (metadata != null) ? metadata.partitions : 0;
-                log.info("Number of partitions reported for topic {}: {}", topicName, numPartitions);
-                if (numPartitions < 1) {
-                    log.warn("Topic '{}' is non-partitioned (partitions={}). It will be treated as a single partition.", topicName, numPartitions);
-                }
-                int effectivePartitions = numPartitions < 1 ? 1 : numPartitions;
+                int effectivePartitions = getEffectivePartitionCount(topicName);
+                log.info("Number of partitions reported for topic {}: {}", topicName, effectivePartitions);
                 for (int i = 0; i < effectivePartitions; i++) {
                     partitionIndexes.add(globalIndex++);
                 }
@@ -303,10 +299,27 @@ public class PulsarSource extends Sourcer {
             if (partitionIndexes.isEmpty()) {
                 partitionIndexes.add(0);
             }
+            log.info("Active partitions: {}", partitionIndexes);
             return partitionIndexes;
         } catch (Exception e) {
             log.error("Error while retrieving partition information. Falling back to default partitions.", e);
             return defaultPartitions();
+        }
+    }
+
+    @Override
+    public Integer getTotalPartitions() {
+        try {
+            Set<String> topicNames = (Set<String>) pulsarConsumerProperties.getConsumerConfig().get("topicNames");
+            int total = 0;
+            for (String topicName : topicNames) {
+                total += getEffectivePartitionCount(topicName);
+            }
+            log.info("Total partitions across {} topic(s): {}", topicNames.size(), total);
+            return total;
+        } catch (PulsarAdminException e) {
+            log.error("Error retrieving total partition count", e);
+            return null;
         }
     }
 

--- a/src/main/java/io/numaproj/pulsar/consumer/PulsarSource.java
+++ b/src/main/java/io/numaproj/pulsar/consumer/PulsarSource.java
@@ -122,11 +122,31 @@ public class PulsarSource extends Sourcer {
         }
     }
 
+    /**
+     * Extracts the partition index from a Pulsar topic name.
+     * Partitioned topics have the format "persistent://tenant/ns/topic-partition-N".
+     * Returns 0 for non-partitioned topics.
+     */
+    private static int extractPartitionIndex(String topicName) {
+        int idx = topicName.lastIndexOf("-partition-");
+        if (idx < 0) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(topicName.substring(idx + "-partition-".length()));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
     /** Builds offset and headers, sends the message to the observer, and records it for ack. */
     private void sendMessage(org.apache.pulsar.client.api.Message<?> pMsg, byte[] payloadBytes, OutputObserver observer) {
         String topicMessageIdKey = pMsg.getTopicName() + pMsg.getMessageId().toString();
         byte[] offsetBytes = topicMessageIdKey.getBytes(StandardCharsets.UTF_8);
-        Offset offset = new Offset(offsetBytes);
+        // Offset offset = new Offset(offsetBytes);
+        // Extract partition from Pulsar message topic name
+        int partition = extractPartitionIndex(pMsg.getTopicName());
+        Offset offset = new Offset(offsetBytes, partition);
         Map<String, String> headers = buildHeaders(pMsg);
         observer.send(new Message(payloadBytes, offset, Instant.now(), headers));
         messagesToAck.put(topicMessageIdKey, pMsg);

--- a/src/test/java/io/numaproj/pulsar/consumer/PulsarSourceTest.java
+++ b/src/test/java/io/numaproj/pulsar/consumer/PulsarSourceTest.java
@@ -483,11 +483,11 @@ public class PulsarSourceTest {
     }
 
     /**
-     * Tests that the method returns a list of partition indexes from 0 to
+     * Tests that getActivePartitions returns a list of partition indexes from 0 to
      * numPartitions-1 for a partitioned topic.
      */
     @Test
-    public void getPartitionsPartitionedTopic() {
+    public void getActivePartitionsPartitionedTopic() {
         PulsarConsumerProperties mockProperties = mock(PulsarConsumerProperties.class);
         Map<String, Object> consumerConfig = new HashMap<>();
         String topicName = "test-topic";
@@ -505,7 +505,7 @@ public class PulsarSourceTest {
             when(mockTopics.getPartitionedTopicMetadata(topicName)).thenReturn(metadata);
 
             PulsarSource source = new PulsarSource(mock(PulsarConsumerManager.class), mockAdmin, mockProperties);
-            List<Integer> result = source.getPartitions();
+            List<Integer> result = source.getActivePartitions();
 
             assertEquals(3, result.size());
             assertEquals(List.of(0, 1, 2), result);
@@ -513,17 +513,17 @@ public class PulsarSourceTest {
             verify(mockTopics).getPartitionedTopicMetadata(topicName);
 
         } catch (PulsarAdminException e) {
-            fail("Unexpected PulsarAdminException thrown in getPartitionsPartitionedTopic: " + e.getMessage());
+            fail("Unexpected PulsarAdminException thrown in getActivePartitionsPartitionedTopic: " + e.getMessage());
         }
 
     }
 
     /**
-     * Tests that a non-partitioned topic (numPartitions < 1) returns a singleton
-     * list containing 0.
+     * Tests that getActivePartitions for a non-partitioned topic (numPartitions < 1)
+     * returns a singleton list containing 0.
      */
     @Test
-    public void getPartitionsNonPartitionedTopic() {
+    public void getActivePartitionsNonPartitionedTopic() {
         PulsarAdmin pulsarAdmin = mock(PulsarAdmin.class);
         Topics topics = mock(Topics.class);
         when(pulsarAdmin.topics()).thenReturn(topics);
@@ -541,18 +541,18 @@ public class PulsarSourceTest {
         when(pulsarConsumerProperties.getConsumerConfig()).thenReturn(consumerConfig);
 
         PulsarSource localSource = new PulsarSource(mock(PulsarConsumerManager.class), pulsarAdmin, pulsarConsumerProperties);
-        List<Integer> partitions = localSource.getPartitions();
+        List<Integer> partitions = localSource.getActivePartitions();
 
         assertEquals(List.of(0), partitions);
     }
 
     /**
-     * Tests that getPartitions returns a flat list of indices across multiple
+     * Tests that getActivePartitions returns a flat list of indices across multiple
      * topics
      * (e.g. topic-a with 3 partitions -> 0,1,2; topic-b with 2 -> 3,4).
      */
     @Test
-    public void getPartitionsMultipleTopics() throws PulsarAdminException {
+    public void getActivePartitionsMultipleTopics() throws PulsarAdminException {
         PulsarConsumerProperties mockProperties = mock(PulsarConsumerProperties.class);
         Map<String, Object> consumerConfig = new HashMap<>();
         Set<String> topicNames = new HashSet<>(Arrays.asList("topic-a", "topic-b"));
@@ -572,7 +572,7 @@ public class PulsarSourceTest {
         when(mockTopics.getPartitionedTopicMetadata("topic-b")).thenReturn(metadataB);
 
         PulsarSource source = new PulsarSource(mock(PulsarConsumerManager.class), mockAdmin, mockProperties);
-        List<Integer> result = source.getPartitions();
+        List<Integer> result = source.getActivePartitions();
 
         assertEquals(5, result.size());
         assertEquals(List.of(0, 1, 2, 3, 4), result);
@@ -585,7 +585,7 @@ public class PulsarSourceTest {
      * defaultPartitions().
      */
     @Test
-    public void getPartitionsException() {
+    public void getActivePartitionsException() {
         // Arrange
         PulsarConsumerProperties mockProperties = mock(PulsarConsumerProperties.class);
         when(mockProperties.getConsumerConfig()).thenThrow(new RuntimeException("Test exception"));
@@ -597,7 +597,7 @@ public class PulsarSourceTest {
             mockedSourcer.when(Sourcer::defaultPartitions).thenReturn(List.of(42));
 
             PulsarSource source = new PulsarSource(mock(PulsarConsumerManager.class), mockAdmin, mockProperties);
-            List<Integer> result = source.getPartitions();
+            List<Integer> result = source.getActivePartitions();
             assertEquals(List.of(42), result);
             mockedSourcer.verify(Sourcer::defaultPartitions);
         }

--- a/src/test/java/io/numaproj/pulsar/consumer/PulsarSourceTest.java
+++ b/src/test/java/io/numaproj/pulsar/consumer/PulsarSourceTest.java
@@ -483,124 +483,30 @@ public class PulsarSourceTest {
     }
 
     /**
-     * Tests that getActivePartitions returns a list of partition indexes from 0 to
-     * numPartitions-1 for a partitioned topic.
+     * getActivePartitions() should delegate to Sourcer.defaultPartitions(), returning
+     * a singleton list containing this replica's index (from NUMAFLOW_REPLICA).
+     * <p>
+     * Pulsar's subscription model dispatches messages across consumers dynamically, so
+     * there is no stable binding between a consumer and specific Pulsar partitions to
+     * report. Each replica reports itself as one logical watermark partition, matching
+     * the upstream Rust Pulsar source.
      */
     @Test
-    public void getActivePartitionsPartitionedTopic() {
+    public void getActivePartitionsReturnsDefaultPartitions() {
         PulsarConsumerProperties mockProperties = mock(PulsarConsumerProperties.class);
-        Map<String, Object> consumerConfig = new HashMap<>();
-        String topicName = "test-topic";
-        Set<String> topicNames = Set.of(topicName);
-        consumerConfig.put("topicNames", topicNames);
-        when(mockProperties.getConsumerConfig()).thenReturn(consumerConfig);
-
-        PulsarAdmin mockAdmin = mock(PulsarAdmin.class);
-        Topics mockTopics = mock(Topics.class);
-        when(mockAdmin.topics()).thenReturn(mockTopics);
-
-        PartitionedTopicMetadata metadata = new PartitionedTopicMetadata();
-        metadata.partitions = 3;
-        try {
-            when(mockTopics.getPartitionedTopicMetadata(topicName)).thenReturn(metadata);
-
-            PulsarSource source = new PulsarSource(mock(PulsarConsumerManager.class), mockAdmin, mockProperties);
-            List<Integer> result = source.getActivePartitions();
-
-            assertEquals(3, result.size());
-            assertEquals(List.of(0, 1, 2), result);
-
-            verify(mockTopics).getPartitionedTopicMetadata(topicName);
-
-        } catch (PulsarAdminException e) {
-            fail("Unexpected PulsarAdminException thrown in getActivePartitionsPartitionedTopic: " + e.getMessage());
-        }
-
-    }
-
-    /**
-     * Tests that getActivePartitions for a non-partitioned topic (numPartitions < 1)
-     * returns a singleton list containing 0.
-     */
-    @Test
-    public void getActivePartitionsNonPartitionedTopic() {
-        PulsarAdmin pulsarAdmin = mock(PulsarAdmin.class);
-        Topics topics = mock(Topics.class);
-        when(pulsarAdmin.topics()).thenReturn(topics);
-        PartitionedTopicMetadata metadata = new PartitionedTopicMetadata();
-        metadata.partitions = 0;
-        try {
-            when(topics.getPartitionedTopicMetadata(anyString())).thenReturn(metadata);
-        } catch (PulsarAdminException e) {
-            fail("Unexpected PulsarAdminException thrown: " + e.getMessage());
-        }
-
-        PulsarConsumerProperties pulsarConsumerProperties = mock(PulsarConsumerProperties.class);
-        Map<String, Object> consumerConfig = new HashMap<>();
-        consumerConfig.put("topicNames", Set.of("test-topic"));
-        when(pulsarConsumerProperties.getConsumerConfig()).thenReturn(consumerConfig);
-
-        PulsarSource localSource = new PulsarSource(mock(PulsarConsumerManager.class), pulsarAdmin, pulsarConsumerProperties);
-        List<Integer> partitions = localSource.getActivePartitions();
-
-        assertEquals(List.of(0), partitions);
-    }
-
-    /**
-     * Tests that getActivePartitions returns a flat list of indices across multiple
-     * topics
-     * (e.g. topic-a with 3 partitions -> 0,1,2; topic-b with 2 -> 3,4).
-     */
-    @Test
-    public void getActivePartitionsMultipleTopics() throws PulsarAdminException {
-        PulsarConsumerProperties mockProperties = mock(PulsarConsumerProperties.class);
-        Map<String, Object> consumerConfig = new HashMap<>();
-        Set<String> topicNames = new HashSet<>(Arrays.asList("topic-a", "topic-b"));
-        consumerConfig.put("topicNames", topicNames);
-        when(mockProperties.getConsumerConfig()).thenReturn(consumerConfig);
-
-        PulsarAdmin mockAdmin = mock(PulsarAdmin.class);
-        Topics mockTopics = mock(Topics.class);
-        when(mockAdmin.topics()).thenReturn(mockTopics);
-
-        PartitionedTopicMetadata metadataA = new PartitionedTopicMetadata();
-        metadataA.partitions = 3;
-        PartitionedTopicMetadata metadataB = new PartitionedTopicMetadata();
-        metadataB.partitions = 2;
-
-        when(mockTopics.getPartitionedTopicMetadata("topic-a")).thenReturn(metadataA);
-        when(mockTopics.getPartitionedTopicMetadata("topic-b")).thenReturn(metadataB);
-
-        PulsarSource source = new PulsarSource(mock(PulsarConsumerManager.class), mockAdmin, mockProperties);
-        List<Integer> result = source.getActivePartitions();
-
-        assertEquals(5, result.size());
-        assertEquals(List.of(0, 1, 2, 3, 4), result);
-        verify(mockTopics).getPartitionedTopicMetadata("topic-a");
-        verify(mockTopics).getPartitionedTopicMetadata("topic-b");
-    }
-
-    /**
-     * Tests that an exception causes the method to fall back to
-     * defaultPartitions().
-     */
-    @Test
-    public void getActivePartitionsException() {
-        // Arrange
-        PulsarConsumerProperties mockProperties = mock(PulsarConsumerProperties.class);
-        when(mockProperties.getConsumerConfig()).thenThrow(new RuntimeException("Test exception"));
-
         PulsarAdmin mockAdmin = mock(PulsarAdmin.class);
 
-        // Mock the static method defaultPartitions()
         try (MockedStatic<Sourcer> mockedSourcer = mockStatic(Sourcer.class)) {
-            mockedSourcer.when(Sourcer::defaultPartitions).thenReturn(List.of(42));
+            mockedSourcer.when(Sourcer::defaultPartitions).thenReturn(List.of(7));
 
             PulsarSource source = new PulsarSource(mock(PulsarConsumerManager.class), mockAdmin, mockProperties);
             List<Integer> result = source.getActivePartitions();
-            assertEquals(List.of(42), result);
+
+            assertEquals(List.of(7), result);
             mockedSourcer.verify(Sourcer::defaultPartitions);
         }
+        // Should not touch pulsar admin — Pulsar topic partitioning is irrelevant here.
+        verifyNoInteractions(mockAdmin);
     }
 
     private static final String AVRO_SCHEMA_JSON = ""


### PR DESCRIPTION
updates numaflow-java, due to changes made in [numaflow](https://github.com/numaproj/numaflow/pull/3287)

Found issues outlined in the current getPartition implementation, thus some changes were made in how the getActivePartition method is implemented. 

**Why watermarks weren't updating properly, causing the window to not close properly**
- Old `getActivePartitions()` (or deprecated method `getPartitions`) returned all Pulsar topic partitions ([0..4]), making Numaflow spin up 5 watermark processors per replica.
- Under Pulsar's Shared subscription, messages from any partition can land on any consumer replica. There's no stable replica -> partition ownership, so multiple replicas end up claiming the same watermark processor IDs with inconsistent progress.
- Low TPS (1 msg / 5s): some partitions never receive data on a given replica, so those processors stay at -1 and the min is pinned low
- High TPS (10k rpu): all partitions receive data, but it's spread across replicas dynamically, so each replica only advances the processors whose messages it happened to see — gaps still stall the min.

**Why this fix works**
- getActivePartitions() now returns `defaultPartitions()` — a singleton with this replica's NUMAFLOW_REPLICA index, so the watermark partition is the replica, not a Pulsar topic partition.
- Each replica owns exactly one watermark processor that it fully controls, so there is no ambiguity, no shared/gapped processors, etc
Matches Numaflow's upstream Rust Pulsar source, which has always modeled things this way.


fixes #87 
